### PR TITLE
update shared data compose

### DIFF
--- a/deploy/docker-compose/docker-compose-shared-data.yml
+++ b/deploy/docker-compose/docker-compose-shared-data.yml
@@ -4,26 +4,21 @@ services:
     container_name: starrocks-minio
     image: minio/minio:latest
     environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
     ports:
       - "9001:9001"
       - "9000:9000"
-    volumes:
-      - starrocks-miniodata:/minio_data
+    # volumes:
+      # - starrocks-miniodata:/minio_data
     entrypoint: sh
     command: '-c ''mkdir -p /minio_data/starrocks && minio server /minio_data --console-address ":9001"'''
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
     networks:
       network:
         ipv4_address: 10.5.0.6
 
   starrocks-fe:
-    image: starrocks/fe-ubuntu:3.0.0-rc01
+    image: starrocks/fe-ubuntu:3.1-latest
     hostname: starrocks-fe
     container_name: starrocks-fe
     user: root
@@ -33,8 +28,8 @@ services:
       echo aws_s3_path=starrocks >> /opt/starrocks/fe/conf/fe.conf &&
       echo aws_s3_endpoint=minio:9000 >> /opt/starrocks/fe/conf/fe.conf &&
       echo aws_s3_use_instance_profile=false >> /opt/starrocks/fe/conf/fe.conf &&
-      echo aws_s3_access_key=minioadmin >> /opt/starrocks/fe/conf/fe.conf &&
-      echo aws_s3_secret_key=minioadmin >> /opt/starrocks/fe/conf/fe.conf &&
+      echo cloud_native_storage_type=S3 >> /opt/starrocks/fe/conf/fe.conf &&
+      echo aws_s3_use_aws_sdk_default_behavior=true >> /opt/starrocks/fe/conf/fe.conf &&
       sh /opt/starrocks/fe/bin/start_fe.sh"
     ports:
       - 8030:8030
@@ -47,49 +42,49 @@ services:
       retries: 3
     depends_on:
       - minio
-    volumes:
+    # volumes:
       # - ./starrocks/starrocks-fe/conf:/opt/starrocks/fe/conf
-      - starrocks-fe-meta:/opt/starrocks/fe/meta
-      - starrocks-fe-log:/opt/starrocks/fe/log
+      # - starrocks-fe-meta:/opt/starrocks/fe/meta
+      # - starrocks-fe-log:/opt/starrocks/fe/log
     networks:
       network:
         ipv4_address: 10.5.0.2
 
-  starrocks-be:
-    image: starrocks/be-ubuntu:3.0.0-rc01
+  starrocks-cn:
+    image: starrocks/cn-ubuntu:3.1-latest
     command:
       - /bin/bash
       - -c
       - |
-        sleep 15s; echo starlet_port = 8167 >> /opt/starrocks/be/conf/be.conf;
-        mysql --connect-timeout 2 -h starrocks-fe -P9030 -uroot -e "alter system add backend \"starrocks-be:9050\";"
-        /opt/starrocks/be/bin/start_be.sh
+        sleep 15s; echo starlet_port = 8167 >> /opt/starrocks/cn/conf/cn.conf;
+        mysql --connect-timeout 2 -h starrocks-fe -P9030 -uroot -e "ALTER SYSTEM ADD COMPUTE NODE \"starrocks-cn:9050\";"
+        /opt/starrocks/cn/bin/start_cn.sh
     ports:
       - 8040:8040
-    hostname: starrocks-be
-    container_name: starrocks-be
+    hostname: starrocks-cn
+    container_name: starrocks-cn
     user: root
     depends_on:
       - starrocks-fe
       - minio
     healthcheck:
-      test: 'mysql -uroot -h10.5.0.2 -P 9030 -e "show backends\G" |grep "Alive: true"'
+      test: 'mysql -uroot -h10.5.0.2 -P 9030 -e "SHOW COMPUTE NODES\G" |grep "Alive: true"'
       interval: 10s
       timeout: 5s
       retries: 3
-    volumes:
-#      - be.conf:/opt/starrocks/be/conf/be.conf
-#      - starrocks-be-storage:/opt/starrocks/be/storage
-      - starrocks-be-log:/opt/starrocks/be/log
+    # volumes:
+      # - be.conf:/opt/starrocks/be/conf/be.conf
+      # - starrocks-be-storage:/opt/starrocks/be/storage
+      # - starrocks-cn-log:/opt/starrocks/cn/log
     networks:
       network:
         ipv4_address: 10.5.0.3
-volumes:
-#  starrocks-be-storage:
-  starrocks-be-log:
-  starrocks-fe-meta:
-  starrocks-fe-log:
-  starrocks-miniodata:
+# volumes:
+  # starrocks-be-storage:
+  # starrocks-cn-log:
+  # starrocks-fe-meta:
+  # starrocks-fe-log:
+  # starrocks-miniodata:
 networks:
   network:
     driver: bridge


### PR DESCRIPTION
- MINIO_ACCESS_KEY is deprecated
- Update to version 3.1 (use CN instead of BE)
- remove persistent volumes as this should be for experiments, not prod use