### PR TITLE
Update shared-data documentation compose file

### DIFF
--- a/documentation-samples/quickstart/docker-compose.yml
+++ b/documentation-samples/quickstart/docker-compose.yml
@@ -25,8 +25,6 @@ services:
 
   minio_mc:
     image: minio/mc:latest
-    environment:
-      MC_HOST_minio: http://miniouser:miniopassword@minio:9000
     entrypoint:
       - sh
       - -c

--- a/documentation-samples/quickstart/docker-compose.yml
+++ b/documentation-samples/quickstart/docker-compose.yml
@@ -36,7 +36,10 @@ services:
         done
 
         mc alias set myminio http://minio:9000 miniouser miniopassword
-        mc admin user svcacct add --access-key CCCCCCC --secret-key BBBBBBBBBBBBBBB myminio miniouser
+        mc admin user svcacct add --access-key AAAAAAAAAAAAAAAAAAAA \
+        --secret-key BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB \
+        myminio \
+        miniouser
     depends_on:
       - minio
     networks:
@@ -52,12 +55,25 @@ services:
       - /bin/bash
       - -c
       - |
-        echo run_mode=shared_data >> /opt/starrocks/fe/conf/fe.conf
-        echo aws_s3_path=starrocks >> /opt/starrocks/fe/conf/fe.conf
-        echo aws_s3_endpoint=minio:9000 >> /opt/starrocks/fe/conf/fe.conf
-        echo aws_s3_use_instance_profile=false >> /opt/starrocks/fe/conf/fe.conf
-        echo cloud_native_storage_type=S3 >> /opt/starrocks/fe/conf/fe.conf
-        echo aws_s3_use_aws_sdk_default_behavior=true >> /opt/starrocks/fe/conf/fe.conf
+        echo "# enable shared data, set storage type, set endpoint" >> /opt/starrocks/fe/conf/fe.conf
+        echo "run_mode = shared_data" >> /opt/starrocks/fe/conf/fe.conf
+        echo "cloud_native_storage_type = S3" >> /opt/starrocks/fe/conf/fe.conf
+        echo "aws_s3_endpoint = minio:9000" >> /opt/starrocks/fe/conf/fe.conf
+
+        echo "# set the path in MinIO" >> /opt/starrocks/fe/conf/fe.conf
+        echo "aws_s3_path = starrocks" >> /opt/starrocks/fe/conf/fe.conf
+
+        echo "# credentials for MinIO object read/write" >> /opt/starrocks/fe/conf/fe.conf
+        echo "aws_s3_access_key = AAAAAAAAAAAAAAAAAAAA" >> /opt/starrocks/fe/conf/fe.conf
+        echo "aws_s3_secret_key = BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" >> /opt/starrocks/fe/conf/fe.conf
+        echo "aws_s3_use_instance_profile = false" >> /opt/starrocks/fe/conf/fe.conf
+        echo "aws_s3_use_aws_sdk_default_behavior = false" >> /opt/starrocks/fe/conf/fe.conf
+
+        echo "# Set this to false if you do not want default" >> /opt/starrocks/fe/conf/fe.conf
+        echo "# storage created in the object storage using" >> /opt/starrocks/fe/conf/fe.conf
+        echo "# the details provided above" >> /opt/starrocks/fe/conf/fe.conf
+        echo "enable_load_volume_from_conf = true" >> /opt/starrocks/fe/conf/fe.conf
+
         /opt/starrocks/fe/bin/start_fe.sh
     ports:
       - 8030:8030

--- a/documentation-samples/quickstart/docker-compose.yml
+++ b/documentation-samples/quickstart/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     ports:
       - "9001:9001"
       - "9000:9000"
-    # volumes:
-      # - starrocks-miniodata:/minio_data
     entrypoint: sh
     command: '-c ''mkdir -p /minio_data/starrocks && minio server /minio_data --console-address ":9001"'''
     healthcheck:
@@ -24,6 +22,11 @@ services:
         ipv4_address: 10.5.0.6
 
   minio_mc:
+    # This service is short lived, it does this:
+    # - starts up
+    # - checks to see if the MinIO service `minio` is ready
+    # - creates a MinIO Access Key that the StarRocks services will use
+    # - exits
     image: minio/mc:latest
     entrypoint:
       - sh
@@ -84,10 +87,6 @@ services:
       retries: 3
     depends_on:
       - minio
-    # volumes:
-      # - ./starrocks/starrocks-fe/conf:/opt/starrocks/fe/conf
-      # - starrocks-fe-meta:/opt/starrocks/fe/meta
-      # - starrocks-fe-log:/opt/starrocks/fe/log
     networks:
       network:
         ipv4_address: 10.5.0.2
@@ -114,19 +113,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-    # volumes:
-      # - be.conf:/opt/starrocks/be/conf/be.conf
-      # - starrocks-be-storage:/opt/starrocks/be/storage
-      # - starrocks-cn-log:/opt/starrocks/cn/log
     networks:
       network:
         ipv4_address: 10.5.0.3
-# volumes:
-  # starrocks-be-storage:
-  # starrocks-cn-log:
-  # starrocks-fe-meta:
-  # starrocks-fe-log:
-  # starrocks-miniodata:
+
 networks:
   network:
     driver: bridge

--- a/documentation-samples/quickstart/docker-compose.yml
+++ b/documentation-samples/quickstart/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       # - starrocks-miniodata:/minio_data
     entrypoint: sh
     command: '-c ''mkdir -p /minio_data/starrocks && minio server /minio_data --console-address ":9001"'''
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
       network:
         ipv4_address: 10.5.0.6
@@ -22,14 +27,17 @@ services:
     hostname: starrocks-fe
     container_name: starrocks-fe
     user: root
-    command: >
-      bash -c "echo run_mode=shared_data >> /opt/starrocks/fe/conf/fe.conf &&
-      echo aws_s3_path=starrocks >> /opt/starrocks/fe/conf/fe.conf &&
-      echo aws_s3_endpoint=minio:9000 >> /opt/starrocks/fe/conf/fe.conf &&
-      echo aws_s3_use_instance_profile=false >> /opt/starrocks/fe/conf/fe.conf &&
-      echo cloud_native_storage_type=S3 >> /opt/starrocks/fe/conf/fe.conf &&
-      echo aws_s3_use_aws_sdk_default_behavior=true >> /opt/starrocks/fe/conf/fe.conf &&
-      sh /opt/starrocks/fe/bin/start_fe.sh"
+    command:
+      - /bin/bash
+      - -c
+      - |
+        echo run_mode=shared_data >> /opt/starrocks/fe/conf/fe.conf
+        echo aws_s3_path=starrocks >> /opt/starrocks/fe/conf/fe.conf
+        echo aws_s3_endpoint=minio:9000 >> /opt/starrocks/fe/conf/fe.conf
+        echo aws_s3_use_instance_profile=false >> /opt/starrocks/fe/conf/fe.conf
+        echo cloud_native_storage_type=S3 >> /opt/starrocks/fe/conf/fe.conf
+        echo aws_s3_use_aws_sdk_default_behavior=true >> /opt/starrocks/fe/conf/fe.conf
+        /opt/starrocks/fe/bin/start_fe.sh
     ports:
       - 8030:8030
       - 9020:9020

--- a/documentation-samples/quickstart/docker-compose.yml
+++ b/documentation-samples/quickstart/docker-compose.yml
@@ -1,11 +1,12 @@
 version: "3"
+
 services:
   minio:
-    container_name: starrocks-minio
-    image: minio/minio:latest
+    container_name: minio
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: miniouser
+      MINIO_ROOT_PASSWORD: miniopassword
+    image: minio/minio:latest
     ports:
       - "9001:9001"
       - "9000:9000"
@@ -21,6 +22,26 @@ services:
     networks:
       network:
         ipv4_address: 10.5.0.6
+
+  minio_mc:
+    image: minio/mc:latest
+    environment:
+      MC_HOST_minio: http://miniouser:miniopassword@minio:9000
+    entrypoint:
+      - sh
+      - -c
+      - |
+        until mc ls minio > /dev/null 2>&1; do
+          sleep 0.5
+        done
+
+        mc alias set myminio http://minio:9000 miniouser miniopassword
+        mc admin user svcacct add --access-key CCCCCCC --secret-key BBBBBBBBBBBBBBB myminio miniouser
+    depends_on:
+      - minio
+    networks:
+      network:
+        ipv4_address: 10.5.0.7
 
   starrocks-fe:
     image: starrocks/fe-ubuntu:3.1-latest


### PR DESCRIPTION
Adds a short lived MinIO client (`mc`) service that:
   - starts up
   - checks to see if the MinIO service `minio` is ready
   - creates a MinIO Access Key that the StarRocks services will use
   - exits
 
This means that we can use the access key in the FE config and create the default storage volume in MinIO
instead of on the BE disk.

cc: @kevincai 