### PR TITLE
Fix bracket position issue #62

### DIFF
--- a/MiscDemo/connect/python/connector.py
+++ b/MiscDemo/connect/python/connector.py
@@ -88,7 +88,7 @@ except mysql.connector.Error as err:
 print("query data successfully")
 print("siteid\tcitycode\tpv")
 for (siteid, citycode, pv) in cursor:
-    print("{}\t{}\t{}").format(siteid, citycode, pv)
+    print("{}\t{}\t{}".format(siteid, citycode, pv))
 
 # drop database
 try:


### PR DESCRIPTION
Fixing issue #62 
Change `MiscDemo/connect/python/connector.py` Line 91
`    print("{}\t{}\t{}").format(siteid, citycode, pv)`
to
`    print("{}\t{}\t{}".format(siteid, citycode, pv))`

The code was from Beijing Dingshi Zongheng Technology Co., Ltd.
It was trying to print some information in a given format. However this intention was not present correctly according to Python syntax. To make it better represent the intention and allow the Python interpreter to execute it correctly, the closing bracket of function call `print` has been moved to the end of the line.

It is not a original creation of mine, somehow it is done through me.