### PR TITLE
Update docker-compose.yml

### DIFF
--- a/documentation-samples/iceberg/docker-compose.yml
+++ b/documentation-samples/iceberg/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: starrocks-fe
     user: root
     command: |
-      sh /opt/starrocks/fe/bin/start_fe.sh --host_type FQDN
+      bash /opt/starrocks/fe/bin/start_fe.sh --host_type FQDN
     ports:
       - 8030:8030
       - 9020:9020
@@ -37,7 +37,7 @@ services:
         echo "block_cache_disk_size = 1073741824" >> /opt/starrocks/be/conf/be.conf
         sleep 15s
         mysql --connect-timeout 2 -h starrocks-fe -P 9030 -u root -e "ALTER SYSTEM ADD BACKEND \"starrocks-be:9050\";"
-        /opt/starrocks/be/bin/start_be.sh
+        bash /opt/starrocks/be/bin/start_be.sh
     ports:
       - 8040:8040
     hostname: starrocks-be


### PR DESCRIPTION
Switch to bash to launch FE and BE

These errors were in the FE logs. `source: not found` and `[[: not found` tell me it is failing because the shell is `sh` and is not `bash` compatible.

```bash
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 58: source: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 60: check_and_update_max_processes: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 69: export_env_from_conf: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 72: source: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 76: [[: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 108: jdk_version: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 109: [[: not found
starrocks-fe  | JAVA_OPTS is not set in fe.conf, use default java options to start fe process: -Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:/opt/starrocks/fe/log/fe.gc.log.20241031-124945:time -Djava.security.policy=/opt/starrocks/fe/conf/udf_security.policy
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 160: detect_jvm_xmx: not found
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 171: [: unexpected operator
starrocks-fe  | /opt/starrocks/fe/bin/start_fe.sh: 179: read_var_from_conf: not found
```