### PR TITLE
fix reference to redpanda console docker image

### DIFF
--- a/documentation-samples/routine-load-shared-data/docker-compose.yml
+++ b/documentation-samples/routine-load-shared-data/docker-compose.yml
@@ -127,7 +127,7 @@ services:
 
   console:
     container_name: redpanda-console
-    image: docker.redpanda.com/vectorized/console:v2.4.3
+    image: docker.redpanda.com/redpandadata/console:v2.4.3
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:


### PR DESCRIPTION
The referenced docker image is no longer available. You can validate this with

```
docker pull docker.redpanda.com/vectorized/console:v2.4.3
```

it will give this error:

```
Error response from daemon: pull access denied for docker.redpanda.com/vectorized/console, repository does not exist or may require 'docker login'
```

Pulling the updated image with

```
docker pull docker.redpanda.com/redpandadata/console:v2.4.3
```

does succeed